### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,22 @@ node_js:
   - "9.11"
   - "10.15"
   - "11.6"
+arch:
+  - amd64
+  - ppc64le
 sudo: false
+jobs: #Disabling the jobs for power support architecture
+  exclude:
+    - arch: ppc64le
+      node_js: "0.8"
+    - arch: ppc64le
+      node_js: "0.10"
+    - arch: ppc64le
+      node_js: "0.12"
+    - arch: ppc64le
+      node_js: "1.8"  
+    - arch: ppc64le
+      node_js: "2.5"
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.